### PR TITLE
added offset for android 15

### DIFF
--- a/app/src/main/java/com/example/geninterviewsampleapp/MainScreenUI.kt
+++ b/app/src/main/java/com/example/geninterviewsampleapp/MainScreenUI.kt
@@ -1,3 +1,4 @@
+
 package com.example.geninterviewsampleapp
 
 import android.content.Context
@@ -15,11 +16,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
@@ -124,7 +128,8 @@ fun MainScreenUI() {
     val bankData = bankDataState.value
 
     if (bankData != null) {
-        Column(modifier = Modifier.fillMaxSize()) {
+        Column(modifier = Modifier.fillMaxSize()
+            .padding(WindowInsets.systemBars.asPaddingValues())) {
             Box(modifier = Modifier.weight(1f)) {
                 when (selectedNavItem) {
                     "home" -> HomeScreen(bankData, context)
@@ -157,7 +162,8 @@ fun MainScreenUI() {
         }
     } else {
         Box(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier.fillMaxSize()
+                .padding(WindowInsets.systemBars.asPaddingValues()),
             contentAlignment = Alignment.Center
         ) {
             Text("Loading...")


### PR DESCRIPTION
--issue found with UI rendering in android 15
--offsets added 

Explanation
WindowInsets.systemBars.asPaddingValues(): Automatically adds padding to avoid overlapping with the system bars (status bar, navigation bar, etc.).
Modifier.padding(): Ensures your content respects the insets.
This will prevent your app's UI from taking up the full screen and overlapping with system UI elements.